### PR TITLE
Mapa centraliza com os ônibus

### DIFF
--- a/client/scripts/form.js
+++ b/client/scripts/form.js
@@ -10,9 +10,15 @@ Template.busQuery.events({
             }
             update = false
 
+            var updateMapPosition = true;
+
             var getBuses = function() {
                 $.get("http://dadosabertos.rio.rj.gov.br/apiTransporte/apresentacao/rest/index.cfm/onibus/"+bus, function(data) {
                     curRoute.updateBuses(data.DATA);
+                    if (updateMapPosition) {
+                        curRoute.recenter()
+                        updateMapPosition = false
+                    }
                 }).fail(function() {
                     clearInterval(update);
                     update = false;

--- a/client/scripts/route.js
+++ b/client/scripts/route.js
@@ -10,12 +10,24 @@ Route = class Route {
 
         this.buses = []
 
+        var min_lat = 200, max_lat = -200,
+            min_lng = 200, max_lng = -200
         for (var i = 0; i < jsonData.length; i++) {
             var bus = new Bus(jsonData[i])
             this.buses.push(bus)
+            if (bus.lat < min_lat) min_lat = bus.lat
+            if (bus.lat > max_lat) max_lat = bus.lat
+            if (bus.lng < min_lng) min_lng = bus.lng
+            if (bus.lng > max_lng) max_lng = bus.lng
         }
+        this.lat = (min_lat + max_lat) / 2
+        this.lng = (min_lng + max_lng) / 2
 
         this.draw()
+    }
+
+    recenter() {
+        GoogleMaps.maps.map.instance.setCenter(new google.maps.LatLng(this.lat, this.lng))
     }
 
     draw() {


### PR DESCRIPTION
Centraliza o mapa quando recebe as informações dos ônibus pela primeira vez.
Só faz isso na primeira vez para o usuário poder mover o mapa enquanto mesmo quando as atualizações estão acontecendo
